### PR TITLE
reapply sqlns stratification to results processing

### DIFF
--- a/src/vivarium_compass_sam/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_compass_sam/model_specifications/branches/scenarios.yaml
@@ -1,4 +1,4 @@
-input_draw_count: 12
+input_draw_count: 50
 random_seed_count: 10
 
 branches:

--- a/src/vivarium_compass_sam/model_specifications/compass_sam.yaml
+++ b/src/vivarium_compass_sam/model_specifications/compass_sam.yaml
@@ -15,9 +15,9 @@ components:
         components:
             - SQLNSTreatment()
 
-            - MortalityObserver('wasting')
-            - DiseaseObserver('lower_respiratory_infections', 'wasting')
-            - CategoricalRiskObserver('child_wasting', 'False', 'sq_lns')
+            - MortalityObserver()
+            - DiseaseObserver('lower_respiratory_infections')
+            - CategoricalRiskObserver('child_wasting')
 
 configuration:
     input_data:


### PR DESCRIPTION
I stripped the SQ-LNS stratification out of results processing, but not out of the observers. I had done this because I upped the coverage of SQ-LNS from 90% to 100% for simplicity and set the start date to the beginning of the sim. 

I don't care whether we stratify or not, since it doesn't actually add any more information, since we already know whether a simulant is covered - if they are covered if and only if it is the sqlns scenario and they are over 6 months old. 

Adding stratification back to the results processing means we aren't forced to re-run, but if we want to re-run anyway removing it will make the run faster.